### PR TITLE
施設内投稿機能に、編集、削除機能を追加

### DIFF
--- a/app/assets/javascripts/care_home_post.js
+++ b/app/assets/javascripts/care_home_post.js
@@ -1,0 +1,10 @@
+$(function(){
+  $('#care_home_post_image').change(function(){
+    var file = $(this).prop('files')[0];
+    var fileReader = new FileReader();
+    fileReader.onloadend = function() {
+        $('.edit_post_image_area').html('<img src="' + fileReader.result + '"/>');
+    }
+    fileReader.readAsDataURL(file);
+  });
+})

--- a/app/assets/javascripts/family_post.js
+++ b/app/assets/javascripts/family_post.js
@@ -3,8 +3,10 @@ $(document).ready(function(){
     mode: 'fade',
     auto: true,
     autoStart: true,
+    prevSelector: '.custom-prev',
+    nextSelector: '.custom-next',
     speed: 3000,
-    pause: 3000,
+    pause: 2000,
     infiniteLoop: true,
     pager: false
   });

--- a/app/assets/stylesheets/_care_home_post.scss
+++ b/app/assets/stylesheets/_care_home_post.scss
@@ -196,6 +196,7 @@
 }
 
 .attention_for_recruit{
-  font-size: 14px;
+  font-size: 12px;
   color: red;
+  margin-bottom: 5px;
 }

--- a/app/assets/stylesheets/_care_home_post.scss
+++ b/app/assets/stylesheets/_care_home_post.scss
@@ -67,6 +67,7 @@
           margin: 0 auto;
           padding-top: 10px;
           box-sizing: border-box;
+
           img{
             width: 100%;      
           }
@@ -83,6 +84,18 @@
           margin: 10px 0 0 80%;
           font-size: $base-font-size;
           color: #59e2e2;
+        }
+        &__edit{
+          height: 20px;
+          width: 8%;
+          margin-left: 82%;
+          display: block;
+          border-radius: 10px;
+          background-color:  $main-color;
+          color: $off-color;
+          font-size: $head-font-size;
+          text-align: center;
+
         }
       }
     }
@@ -102,33 +115,63 @@
   padding: 15px 1%;
   box-sizing: border-box;
   &_inner{
-    height: 30px;
-    width: 100%;
-    form{
-      height: 100%;
+    @include post_form_inner;
+  }
+}
+
+.edit_post_main{
+  height: calc(100% - 120px);
+  width: 100%;
+  margin-top: 120px;
+  .edit_post{
+    width: 60%;
+    background-color: $main-rgba;
+    margin: 0 auto;
+    border-radius: 20px;
+    padding: 50px 5%;
+    box-sizing: border-box;
+    .edit_post_image_area{
+      width: 80%;
+      margin: 0 auto;
+      .edit_post_image{
+        width: 100%;
+      }
+      img{
+        width: 100%;
+      }
+    }
+    .edit_posts_form_inner{
+      height: 30px;
       width: 100%;
-      .post_form_inner__title{
-        height: 30px;
-        width: 89%;
-        background-color: $off-color;
-        padding: 0 8% 0 1%;
-        font-size: $base-font-size;
-      }
-      .post_form_inner__image--btn{
-        display: none;
-      }
-      .post_form_inner__image--icon{
-        position: absolute;
-        right: 15%;
-        bottom: 22px;
-        cursor:pointer
-      }
-      .post_form_inner__submit{
-        height: 30px;
-        width: 9%;
-        font-size: $base-font-size;
-        background-color: $sub-color;
+      margin-top: 20px;
+      position: relative;
+      form{
+        height: 100%;
+        width: 100%;
+        .post_form_inner__title{
+          height: 30px;
+          width: 89%;
+          background-color: $off-color;
+          padding: 0 8% 0 1%;
+          font-size: $base-font-size;
+        }
+        .post_form_inner__image--btn{
+          display: none;
+        }
+        .post_form_inner__image--icon{
+          position: absolute;
+          right: 14%;
+          bottom: 6px;
+          cursor:pointer
+        }
+        .post_form_inner__submit{
+          height: 30px;
+          width: 9%;
+          font-size: $base-font-size;
+          background-color: $sub-color;
+        }
       }
     }
   }
 }
+

--- a/app/assets/stylesheets/_care_home_post.scss
+++ b/app/assets/stylesheets/_care_home_post.scss
@@ -95,7 +95,6 @@
           color: $off-color;
           font-size: $head-font-size;
           text-align: center;
-
         }
       }
     }
@@ -128,7 +127,7 @@
     background-color: $main-rgba;
     margin: 0 auto;
     border-radius: 20px;
-    padding: 50px 5%;
+    padding: 50px 5% 20px;
     box-sizing: border-box;
     .edit_post_image_area{
       width: 80%;
@@ -167,10 +166,25 @@
         .post_form_inner__submit{
           height: 30px;
           width: 9%;
-          font-size: $base-font-size;
-          background-color: $sub-color;
+          border-radius: 15px;
+          font-size: $head-font-size;
+          background-color: $main-color;
+          color: $off-color;
+          border: none;
         }
       }
+    }
+    .detete_post{
+      height: 30px;
+      width: 9%;
+      margin: 30px 0 0 95%;
+      display: block;
+      border-radius: 15px;
+      text-align: center;
+      line-height: 30px;
+      color: black;
+      font-size: $base-font-size;
+      background-color: $sub-color;
     }
   }
 }

--- a/app/assets/stylesheets/mixin/_mixin.scss
+++ b/app/assets/stylesheets/mixin/_mixin.scss
@@ -163,3 +163,34 @@
     }
   }
 }
+
+@mixin post_form_inner{
+  height: 30px;
+  width: 100%;
+  form{
+    height: 100%;
+    width: 100%;
+    .post_form_inner__title{
+      height: 30px;
+      width: 89%;
+      background-color: $off-color;
+      padding: 0 8% 0 1%;
+      font-size: $base-font-size;
+    }
+    .post_form_inner__image--btn{
+      display: none;
+    }
+    .post_form_inner__image--icon{
+      position: absolute;
+      right: 15%;
+      bottom: 22px;
+      cursor:pointer
+    }
+    .post_form_inner__submit{
+      height: 30px;
+      width: 9%;
+      font-size: $base-font-size;
+      background-color: $sub-color;
+    }
+  }
+}

--- a/app/controllers/care_home_posts_controller.rb
+++ b/app/controllers/care_home_posts_controller.rb
@@ -14,7 +14,7 @@ class CareHomePostsController < ApplicationController
 
     #以下、awsRekognitionによる顔認証と登録済のuserとの照合
     image_path = care_home_post_params[:image].original_filename #顔認証で必要となる投稿写真のファイル名のみを抽出
-    users = search_all_users_in_photo(image_path)  #投稿された写真に写っている人物全員を特定
+    users = search_all_users_in_photo(@care_home_post, image_path)  #投稿された写真に写っている人物全員を特定
     
     if users.present? #投稿された写真と、登録されていたuserの顔が一致した場合
       save_user_care_home_posts(users, @care_home_post)  #userとcare_home_postの中間テーブルに、user_idとcare_home_post_idを保存
@@ -24,6 +24,38 @@ class CareHomePostsController < ApplicationController
       users_name = users.map{ |user| user.name + "様"}.join(', ')
       redirect_to root_path, notice: "#{users_name} のご家族に通知を送信しました" and return
     end
+    redirect_to root_path
+  end
+
+  def edit
+    @care_home_post = CareHomePost.find(params[:id])
+  end
+
+  def update
+    care_home_post = CareHomePost.find(params[:id])
+    care_home_post.update(care_home_post_params)
+
+    if care_home_post_params[:image].present? #imageに変更があった場合、createと同様に顔認証の手順を行う
+      UserCareHomePost.where(care_home_post_id: params[:id]).destroy_all #userテーブルとの中間テーブルの削除
+
+      image_path = care_home_post_params[:image].original_filename #顔認証で必要となる投稿写真のファイル名のみを抽出
+      users = search_all_users_in_photo(care_home_post, image_path)  #投稿された写真に写っている人物全員を特定し、変数usersとして定義
+      
+      if users.present? #投稿された写真と、登録されていたuserの顔が一致した場合
+        save_user_care_home_posts(users, care_home_post)  #userとcare_home_postの中間テーブルに、user_idとcare_home_post_idを保存
+        send_mail(users) #各userの登録アドレスに通知メール送信
+
+        #送信先をフラッシュメーセージで通知
+        users_name = users.map{ |user| user.name + "様"}.join(', ')
+        redirect_to root_path, notice: "#{users_name} のご家族に通知を送信しました" and return
+      end
+    end
+    redirect_to root_path
+  end
+
+  def destroy
+    care_home_post = CareHomePost.find(params[:id])
+    care_home_post.destroy
     redirect_to root_path
   end
 

--- a/app/controllers/concerns/common_actions.rb
+++ b/app/controllers/concerns/common_actions.rb
@@ -11,7 +11,7 @@ module CommonActions
       )
   end
 
-  def registration_face(image_path)   #写真に写っている全ての人物のface_idを取得しrekognitionに登録
+  def registration_face(record, image_path)   #写真に写っている全ての人物のface_idを取得しrekognitionに登録
 
     begin
       result = client.index_faces({    #rekoognitonのface_id取得API
@@ -19,7 +19,7 @@ module CommonActions
         image: {
           s3_object: {
             bucket: "care-work-support",
-            name: "uploads/#{image_path}",
+            name: "uploads/#{record.class.to_s.underscore}/image/#{record.id}/#{image_path}"
           },
         }
       })
@@ -47,9 +47,9 @@ module CommonActions
 
   end
  
-  def search_all_users_in_photo(image_path) #一つの写真に写っている全ての人物に対し、登録されているユーザーの全てのface_idから、最も一致率の高いface_idを抽出
+  def search_all_users_in_photo(record, image_path) #一つの写真に写っている全ての人物に対し、登録されているユーザーの全てのface_idから、最も一致率の高いface_idを抽出
 
-    face_ids = registration_face(image_path)
+    face_ids = registration_face(record, image_path)
     if face_ids.present?
       match_face_ids = face_ids.map do |face_id|
         search_face(face_id)
@@ -90,6 +90,11 @@ module CommonActions
     users.each do |user|
       care_home_post.user_care_home_posts.create(user_id: user.id)
     end
+  end
+
+  def delete_user_care_home_posts(care_home_post)
+    binding.pry
+    care_home_post.user_care_home_posts.destroy
   end
 
   def send_mail(users)

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -17,7 +17,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     super
     if resource.persisted? #登録が成功した場合に続く処理
       image_path = image_params[:image].original_filename
-      face_ids = registration_face(image_path) #写真に写っている全ての人物のface_idを取得しrekognitionに登録
+      face_ids = registration_face(@user, image_path) #写真に写っている全ての人物のface_idを取得しrekognitionに登録
       if face_ids.present? #登録が成功し、さらに顔認証も成功した場合
         save_face_id(face_ids, @user) #face_idsから、最も一致率の高い人物のface_idを抜き出し、userテーブルに登録
         @user.build_family_room.save #ユーザー専用のfamily_roomを生成   

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -11,7 +11,7 @@ class ImageUploader < CarrierWave::Uploader::Base
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:
   def store_dir
-    "uploads"
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
   end
 
   # Provide a default URL as a default if there hasn't been a file uploaded:

--- a/app/views/care_home_posts/edit.html.haml
+++ b/app/views/care_home_posts/edit.html.haml
@@ -1,0 +1,16 @@
+= render partial: "layouts/navbar"
+
+.edit_post_main
+  .edit_post
+    .edit_post_image_area
+      = image_tag @care_home_post.image.url, class: "edit_post_image"
+
+    .edit_posts_form_inner
+      = form_with(model: @care_home_post, local: true, class: "edit_post_form") do |f|
+        = f.text_field :title, class: "post_form_inner__title", placeholder: 'タイトルを入力してください'
+        = f.label :image, class: "post_form_inner__image" do
+          = icon('fas', 'camera', class: 'post_form_inner__image--icon')
+          = f.file_field :image, class: "post_form_inner__image--btn"
+        = f.submit '変更', class: "post_form_inner__submit"
+      = link_to care_home_post_path, method: :delete, class: "detete_post" do
+        .i.fa.fa-edit

--- a/app/views/care_home_posts/edit.html.haml
+++ b/app/views/care_home_posts/edit.html.haml
@@ -12,5 +12,4 @@
           = icon('fas', 'camera', class: 'post_form_inner__image--icon')
           = f.file_field :image, class: "post_form_inner__image--btn"
         = f.submit '変更', class: "post_form_inner__submit"
-      = link_to care_home_post_path, method: :delete, class: "detete_post" do
-        .i.fa.fa-edit
+    = link_to "削除", care_home_post_path, method: :delete, class: "detete_post"

--- a/app/views/care_home_posts/index.html.haml
+++ b/app/views/care_home_posts/index.html.haml
@@ -22,6 +22,5 @@
           
           = link_to "編集", "care_home_posts/#{care_home_post.id}/edit", class: "post__edit"
 
-
 - if current_user.role == "admin"
   = render partial: "post_form"

--- a/app/views/care_home_posts/index.html.haml
+++ b/app/views/care_home_posts/index.html.haml
@@ -19,8 +19,8 @@
               = care_home_post.title
           .post__creater_at
             = care_home_post.created_at.strftime("%Y/%m/%d")
-          
-          = link_to "編集", "care_home_posts/#{care_home_post.id}/edit", class: "post__edit"
+          - if current_user.role == "admin"
+            = link_to "編集", "care_home_posts/#{care_home_post.id}/edit", class: "post__edit"
 
 - if current_user.role == "admin"
   = render partial: "post_form"

--- a/app/views/care_home_posts/index.html.haml
+++ b/app/views/care_home_posts/index.html.haml
@@ -19,6 +19,9 @@
               = care_home_post.title
           .post__creater_at
             = care_home_post.created_at.strftime("%Y/%m/%d")
+          
+          = link_to "編集", "care_home_posts/#{care_home_post.id}/edit", class: "post__edit"
+
 
 - if current_user.role == "admin"
   = render partial: "post_form"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,3 +1,4 @@
+= render 'layouts/flash'
 = render partial: "layouts/navbar"
 
 .users_search

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -6,7 +6,7 @@ set :application, 'care_work_support'
 set :repo_url,  'git@github.com:yudai-start/care_work_support.git'
 
 # 使用するbranchを指定。 指定がなければmasterを使う。
-set :branch, 'master'
+set :branch, 'add-edit-post-system'
 
 set :linked_dirs, fetch(:linked_dirs, []).push('log', 'tmp/pids', 'tmp/cache', 'tmp/sockets', 'vendor/bundle', 'public/system', 'public/uploads')
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
    }
 
   root to: "care_home_posts#index"
-  resources :care_home_posts, only: [:index, :create]
+  resources :care_home_posts, only: [:index, :create, :update, :edit, :destroy]
   resources :users, only: [:index]
   resources :family_rooms, only: [:index] do
     resources :family_posts, only: [:index, :create]


### PR DESCRIPTION
# What
care_home_postのページに、編集、削除の機能を追加。
- care_home_postコントローラーに、edit、destroyメソッドを定義  
写真が変更された場合のみ、create同様の顔認証を実施
- ビューを編集  
写真が変更した場合、プレビューで画像を表示

# Why
care_home_postのページに、編集、削除の機能を持たせるため